### PR TITLE
zabbix.api is deprecated, changed to pyzabbix

### DIFF
--- a/externalscripts/pyora-items-list.py
+++ b/externalscripts/pyora-items-list.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from zabbix.api import ZabbixAPI
+from pyzabbix import ZabbixAPI
 import argparse
 import sys
 


### PR DESCRIPTION
zabbix.api is deprecated, thus changed to pyzabbix in pyora-items-list.py